### PR TITLE
[nightshift] Backward-compat: fix test ID format drift + export SearchStore

### DIFF
--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,3 +1,4 @@
 from .cosmos import CosmosStore
+from .search import SearchStore
 
-__all__ = ["CosmosStore"]
+__all__ = ["CosmosStore", "SearchStore"]

--- a/tests/test_correlator_smoke.py
+++ b/tests/test_correlator_smoke.py
@@ -53,7 +53,7 @@ class _InMemorySearchStore:
 def test_correlator_pipeline_runs_without_live_azure() -> None:
     threats = [
         {
-            "id": "nvd:CVE-2026-0001",
+            "id": "nvd-CVE-2026-0001",
             "source": "nvd",
             "type": "cve",
             "title": "CVE-2026-0001",
@@ -65,7 +65,7 @@ def test_correlator_pipeline_runs_without_live_azure() -> None:
             "raw": {"source": "nvd"},
         },
         {
-            "id": "otx:ipv4:1.2.3.4",
+            "id": "otx-ipv4-1-2-3-4",
             "source": "otx",
             "type": "indicator",
             "title": "Exploit traffic from 1.2.3.4",
@@ -81,9 +81,9 @@ def test_correlator_pipeline_runs_without_live_azure() -> None:
         },
     ]
     hits_by_source_id = {
-        "nvd:CVE-2026-0001": [
+        "nvd-CVE-2026-0001": [
             {
-                "id": "otx:ipv4:1.2.3.4",
+                "id": "otx-ipv4-1-2-3-4",
                 "source": "otx",
                 "type": "indicator",
                 "score": 0.91,
@@ -92,9 +92,9 @@ def test_correlator_pipeline_runs_without_live_azure() -> None:
                 "content": "CVE-2026-0001 1.2.3.4 exploit malware",
             }
         ],
-        "otx:ipv4:1.2.3.4": [
+        "otx-ipv4-1-2-3-4": [
             {
-                "id": "nvd:CVE-2026-0001",
+                "id": "nvd-CVE-2026-0001",
                 "source": "nvd",
                 "type": "cve",
                 "score": 0.84,

--- a/tests/test_prioritization_scoring.py
+++ b/tests/test_prioritization_scoring.py
@@ -69,7 +69,7 @@ def _build_threat(
 ) -> UnifiedThreat:
     return UnifiedThreat.model_validate(
         {
-            "id": "nvd:CVE-2026-0100",
+            "id": "nvd-CVE-2026-0100",
             "source": "nvd",
             "type": "cve",
             "title": title,


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** Backward-Compatibility Checks
**Category:** pr
**Changes:**

### Test ID Format Drift Fix
- `test_correlator_smoke.py`: Updated test threat IDs from old colon-format (`nvd:CVE-2026-0001`, `otx:ipv4:1.2.3.4`) to new hyphen-format (`nvd-CVE-2026-0001`, `otx-ipv4-1-2-3-4`) to match the actual normalization output. The normalization functions changed from colon-separated to hyphen-separated IDs in commit `c4b98dd`, but test files were not updated, creating a test-production inconsistency.

- `test_prioritization_scoring.py`: Updated test threat ID from `nvd:CVE-2026-0100` to `nvd-CVE-2026-0100`.

### Missing Public API Export Fix
- `src/storage/__init__.py`: Added `SearchStore` to exports. Previously only `CosmosStore` was exported, despite `SearchStore` being used by `correlator_agent.py` throughout the pipeline.

### Additional Findings (no code changes, for awareness)
- **CRITICAL**: ID format migration from colon-separated to hyphen-separated has no data migration script. Existing Cosmos DB records with old-format IDs will not match newly normalized records.
- **HIGH**: Azure SDK dependencies (`azure-cosmos`, `azure-search-documents`, `azure-identity`) are completely unpinned.
- **MEDIUM**: No deprecation framework, no `__version__` attribute, no changelog.
- **MEDIUM**: `get_settings()` uses `@lru_cache(maxsize=1)` with no cache invalidation.

All 5 affected tests pass.

Merge if useful, close if not.