### PR TITLE
[nightshift] ci-fixes: add ruff lint step to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Run ruff check
+        run: uv run ruff check src/ tests/
+
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** ci-fixes
**Category:** pr
**Changes:**
- Add dedicated `lint` job that runs `ruff check src/ tests/` before tests
- The project already has ruff as a dev dependency but CI only ran tests
- Lint and test jobs now run in parallel for faster feedback

Merge if useful, close if not.